### PR TITLE
feat(handle config change): Handling Configuration Changes

### DIFF
--- a/app/src/main/java/adapters/GithubUsersAdapter.java
+++ b/app/src/main/java/adapters/GithubUsersAdapter.java
@@ -19,7 +19,7 @@ import model.GithubUsers;
 import view.DetailActivity;
 
 public class GithubUsersAdapter extends RecyclerView.Adapter<GithubUsersAdapter.GithubUserViewHolder> {
-    Context context;
+    private Context context;
     private List<GithubUsers> githubUsers;
 
     public GithubUsersAdapter(Context context, List<GithubUsers> listOfGithubUsers) {

--- a/app/src/main/java/model/GithubUsers.java
+++ b/app/src/main/java/model/GithubUsers.java
@@ -1,8 +1,11 @@
 package model;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.SerializedName;
 
-public class GithubUsers {
+public class GithubUsers implements Parcelable {
     @SerializedName("avatar_url")
     private String profilePicture;
     @SerializedName("login")
@@ -13,6 +16,26 @@ public class GithubUsers {
     private String followersUrl;
     @SerializedName("following_url")
     private String followingUrl;
+
+    protected GithubUsers(Parcel in) {
+        profilePicture = in.readString();
+        username = in.readString();
+        bio = in.readString();
+        followersUrl = in.readString();
+        followingUrl = in.readString();
+    }
+
+    public static final Creator<GithubUsers> CREATOR = new Creator<GithubUsers>() {
+        @Override
+        public GithubUsers createFromParcel(Parcel in) {
+            return new GithubUsers(in);
+        }
+
+        @Override
+        public GithubUsers[] newArray(int size) {
+            return new GithubUsers[size];
+        }
+    };
 
     public String getProfilePicture() {
         return profilePicture;
@@ -52,5 +75,19 @@ public class GithubUsers {
 
     public void setFollowingUrl(String followingUrl) {
         this.followingUrl = followingUrl;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(profilePicture);
+        dest.writeString(username);
+        dest.writeString(bio);
+        dest.writeString(followersUrl);
+        dest.writeString(followingUrl);
     }
 }

--- a/app/src/main/java/view/MainActivity.java
+++ b/app/src/main/java/view/MainActivity.java
@@ -1,13 +1,14 @@
 package view;
 
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 
 import com.levelup.bibangamba.githubusers.R;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import adapters.GithubUsersAdapter;
@@ -15,14 +16,19 @@ import model.GithubUsers;
 import presenter.GithubUsersPresenter;
 
 public class MainActivity extends AppCompatActivity implements GithubUsersView {
+    public static final String LIST_STATE_KEY = "recycler_list_state";
+    public static final String GITHUB_USERS = "retrieved_github_users";
     RecyclerView githubUsersRecyclerView;
+    Parcelable listState;
+    RecyclerView.LayoutManager layoutManager;
+    ArrayList<GithubUsers> retrievedGithubUsers;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         githubUsersRecyclerView = findViewById(R.id.recycler_view);
         githubUsersRecyclerView.setHasFixedSize(true);
-        RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(MainActivity.this);
+        layoutManager = new LinearLayoutManager(MainActivity.this);
         githubUsersRecyclerView.setLayoutManager(layoutManager);
         GithubUsersPresenter githubUsersPresenter = new GithubUsersPresenter(this, this);
         githubUsersPresenter.getGithubUsers();
@@ -30,6 +36,32 @@ public class MainActivity extends AppCompatActivity implements GithubUsersView {
 
     @Override
     public void githubUsersHaveBeenFetchedAndAreReadyForUse(List<GithubUsers> githubUsers) {
+        retrievedGithubUsers = (ArrayList<GithubUsers>) githubUsers;
         githubUsersRecyclerView.setAdapter(new GithubUsersAdapter(MainActivity.this, githubUsers));
+    }
+
+
+    protected void onSaveInstanceState(Bundle state) {
+        super.onSaveInstanceState(state);
+        state.putParcelableArrayList(GITHUB_USERS, retrievedGithubUsers);
+        listState = layoutManager.onSaveInstanceState();
+        state.putParcelable(LIST_STATE_KEY, listState);
+    }
+
+    protected void onRestoreInstanceState(Bundle state) {
+        super.onRestoreInstanceState(state);
+        if (state != null){
+            retrievedGithubUsers = state.getParcelableArrayList(GITHUB_USERS);
+            listState = state.getParcelable(LIST_STATE_KEY);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (listState != null) {
+            githubUsersRecyclerView.setAdapter(new GithubUsersAdapter(MainActivity.this, retrievedGithubUsers));
+            layoutManager.onRestoreInstanceState(listState);
+        }
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Ensures we handle configuration changes by the activity's/object's previous state

#### Description of tasks to be done?
- ensure that GithubUsers implements Parcelable
- add implementation to save recyclerview state before the activity is destroyed and restore it when the activity resumes

#### How can this be manually tested?
clone the branch and run the application. It should start out on the list of GitHub users.
- scroll down to the middle of the list; 
- change the configuration by rotating the screen (changing to landscape orientation).
- the list item that was at the top before should still be at the top

#### What are the relevant pivotal tracker stories?
[#156005187
](https://www.pivotaltracker.com/story/show/156005187)

#### Screenshots
![image](https://i.imgur.com/Qa6H3v1.gif)
